### PR TITLE
feat(database): Thêm Models, Factory, Migrations và Seeder

### DIFF
--- a/app/Models/Author.php
+++ b/app/Models/Author.php
@@ -2,9 +2,23 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Author extends Model
 {
-    //
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'avatar',
+        'bio'
+    ];
+
+    // Quan hệ
+    public function books()
+    {
+        return $this->hasMany(Book::class);
+    }
 }

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -2,9 +2,49 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Book extends Model
 {
-    //
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'slug',
+        'category_id',
+        'author_id',
+        'publisher',
+        'published_year',
+        'description',
+        'cover_image',
+        'view_count',
+        'avg_rating',
+    ];
+
+    protected $casts = [
+        'avg_rating' => 'float',
+    ];
+
+    // Quan hệ
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(Author::class);
+    }
+
+    public function reviews()
+    {
+        return $this->hasMany(Review::class);
+    }
+
+    // Sách nằm trong kệ sách của người dùng
+    public function inBookshelves()
+    {
+        return $this->hasMany(Bookshelf::class);
+    }
 }

--- a/app/Models/Bookshelf.php
+++ b/app/Models/Bookshelf.php
@@ -2,9 +2,35 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Bookshelf extends Model
 {
-    //
+    // Ghi chú: Chưa có Factory cho Bookshelf
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'book_id',
+        'status',
+        'started_at',
+        'finished_at'
+    ];
+
+    protected $casts = [
+        'started_at' => 'date',
+        'finished_at' => 'date',
+    ];
+
+    // Quan hệ
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function book()
+    {
+        return $this->belongsTo(Book::class);
+    }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,9 +2,22 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Category extends Model
 {
-    //
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'description'
+    ];
+
+    // Quan hệ
+    public function books()
+    {
+        return $this->hasMany(Book::class);
+    }
 }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -2,9 +2,29 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
-    //
+    // Ghi chú: Chưa có Factory cho Comment
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'review_id',
+        'content'
+    ];
+
+    // Quan hệ
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function review()
+
+    {
+        return $this->belongsTo(Review::class);
+    }
 }

--- a/app/Models/Follow.php
+++ b/app/Models/Follow.php
@@ -2,9 +2,19 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Follow extends Model
 {
-    //
+    // Ghi chú: Chưa có Factory cho Follow
+    use HasFactory;
+
+    protected $fillable = [
+        'follower_id',
+        'following_id'
+    ];
+
+    // Quan hệ
+    // Ghi chú: Đã định nghĩa quan hệ bên User
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -2,9 +2,27 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Like extends Model
 {
-    //
+    // Ghi chú: Chưa có Factory cho Like
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'review_id'
+    ];
+
+    // Quan hệ
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function review()
+    {
+        return $this->belongsTo(Review::class);
+    }
 }

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -2,9 +2,45 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Review extends Model
 {
-    //
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'book_id',
+        'rating',
+        'content_text',
+        'is_approved',
+    ];
+
+    protected $casts = [
+        'is_approved' => 'boolean',
+        'rating' => 'float',
+    ];
+
+    // Quan hệ
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function book()
+    {
+        return $this->belongsTo(Book::class);
+    }
+
+    // Một bài đánh giá có nhiều bình luận và lượt thích
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,10 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'avatar',
+        'bio',
+        'role',
+        'is_active',
     ];
 
     /**
@@ -43,6 +47,39 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_active' => 'boolean',
         ];
+    }
+
+    // Quan hệ
+    public function reviews()
+    {
+        return $this->hasMany(Review::class);
+    }
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
+
+    public function bookshelf()
+    {
+        return $this->hasMany(Bookshelf::class);
+    }
+
+    // Quan hệ giữa người dùng và người theo dõi
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'following_id', 'follower_id');
+    }
+
+    public function followings()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'follower_id', 'following_id');
     }
 }

--- a/database/factories/AuthorFactory.php
+++ b/database/factories/AuthorFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Author>
+ */
+class AuthorFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        // Ghi chú: Tạo tên đầy đủ
+        $name = fake()->lastName() . ' ' . fake()->middleName() . ' ' . fake()->firstName();
+        $bios = [
+            "Tác giả $name là một trong những cây bút xuất sắc của văn học đương đại. Với giọng văn nhẹ nhàng nhưng sâu lắng, các tác phẩm của $name luôn chạm đến những góc khuất sâu kín nhất trong tâm hồn người đọc.",
+            "$name nổi tiếng với tư duy logic sắc bén và phong cách kể chuyện đầy kịch tính. Những cuốn sách của $name thường dẫn dắt độc giả đi từ bất ngờ này đến bất ngờ khác, với những cái kết không thể đoán trước.",
+            "Không chỉ là một tác giả, $name còn là một diễn giả truyền cảm hứng được yêu thích. Những cuốn sách của $name mang đậm tính thực tiễn, giúp hàng ngàn độc giả thay đổi tư duy và làm chủ cuộc sống.",
+            "Sinh ra và lớn lên trong thời kỳ đổi mới, văn chương của $name mang đậm hơi thở của cuộc sống đời thường. $name viết về những điều giản dị bằng một trái tim đa cảm và giàu lòng trắc ẩn.",
+            "$name là một nhà nghiên cứu tâm huyết với nhiều năm kinh nghiệm. Các tác phẩm của $name là sự kết hợp hoàn hảo giữa kiến thức chuyên sâu và lối diễn giải gãy gọn, dễ hiểu.",
+            "Một cây bút trẻ đầy triển vọng của làng văn. $name được biết đến với phong cách viết phóng khoáng, hiện đại và không ngại thử thách với những đề tài gai góc.",
+            "Tác giả $name đã dành cả cuộc đời để cống hiến cho sự nghiệp văn học. Các tác phẩm của ông/bà đã được dịch ra nhiều thứ tiếng và nhận được nhiều giải thưởng danh giá trong và ngoài nước.",
+            "Chưa thiết lập tiểu sử cho tác giả này.",
+        ];
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'avatar' => 'https://ui-avatars.com/api/?name=' . urlencode($name) . '&background=random&color=fff',
+            'bio' => fake()->randomElement($bios),
+        ];
+    }
+}

--- a/database/factories/BookFactory.php
+++ b/database/factories/BookFactory.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Author;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Book>
+ */
+class BookFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $titleBook = [
+            'Dế Mèn Phiêu Lưu Ký',
+            'Đất Rừng Phương Nam',
+            'Số Đỏ',
+            'Tắt Đèn',
+            'Chí Phèo',
+            'Lão Hạc',
+            'Vợ Nhặt',
+            'Rừng Xà Nu',
+            'Mắt Biếc',
+            'Tôi Thấy Hoa Vàng Trên Cỏ Xanh',
+            'Cho Tôi Xin Một Vé Đi Tuổi Thơ',
+            'Cánh Đồng Bất Tận',
+            'Nỗi Buồn Chiến Tranh',
+            'Tuổi Thơ Dữ Dội',
+            'Nhà Giả Kim',
+            'Hoàng Tử Bé',
+            'Ông Già Và Biển Cả',
+            'Rừng Na Uy',
+            'Trăm Năm Cô Đơn',
+            'Giết Con Chim Nhại',
+            'Bắt Trẻ Đồng Xanh',
+            'Không Gia Đình',
+            'Những Người Khốn Khổ',
+            'Thép Đã Tôi Thế Đấy',
+            'Tiếng Chim Hót Trong Bụi Mận Gai',
+            'Đồi Gió Hú',
+            'Kiêu Hãnh Và Định Kiến',
+            'Harry Potter và Hòn Đá Phù Thủy',
+            'Chúa Tể Những Chiếc Nhẫn',
+            'Sherlock Holmes',
+            'Án Mạng Trên Chuyến Tàu Tốc Hành Phương Đông',
+            'Sự Im Lặng Của Bầy Cừu',
+            'Mật Mã Da Vinci',
+            'Kỳ Án Ánh Trăng',
+            'Đề Thi Đẫm Máu',
+            'Phía Sau Nghi Can X',
+            'Bạch Dạ Hành',
+            'Hỏa Ngục',
+            'Cô Gái Có Hình Xăm Rồng',
+            'Đắc Nhân Tâm',
+            'Nhà Lãnh Đạo Không Chức Danh',
+            'Cà Phê Cùng Tony',
+            'Tuổi Trẻ Đáng Giá Bao Nhiêu',
+            'Đời Thay Đổi Khi Chúng Ta Thay Đổi',
+            'Dạy Con Làm Giàu',
+            'Chiến Tranh Tiền Tệ',
+            'Tỷ Phú Bán Giày',
+            'Khởi Nghiệp Tinh Gọn',
+            'Nhà Đầu Tư Thông Minh',
+            'Code Dạo Ký Sự',
+            'Clean Code',
+            'Lập Trình Viên Pragmatic',
+            'Tớ Học Lập Trình',
+            'Design Patterns',
+            'Nhập Môn Trí Tuệ Nhân Tạo'
+        ];
+
+        $publishers = [
+            'NXB Trẻ',
+            'NXB Kim Đồng',
+            'NXB Hội Nhà Văn',
+            'NXB Lao Động',
+            'NXB Phụ Nữ',
+            'NXB Thanh Niên',
+            'NXB Văn Học',
+            'NXB Dân Trí',
+            'NXB Thế Giới',
+            'NXB Tổng hợp TP.HCM',
+            'NXB Chính Trị Quốc Gia Sự Thật',
+            'Nhã Nam',
+            'Đinh Tị Books',
+            'Đông A',
+            'Skybooks',
+            'Alpha Books',
+            'Thái Hà Books'
+        ];
+
+        // Tạo tiêu đề sách ngẫu nhiên: xóa dấu chấm ở cuối câu
+        $title = fake()->unique()->randomElement($titleBook);
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title),
+            // Lấy ngẫu nhiên id từ bảng categories, nếu không có thì tạo mới
+            'category_id' => Category::query()->inRandomOrder()->value('id') ?? Category::factory(),
+            // Lấy ngẫu nhiên id từ bảng authors
+            'author_id' => Author::query()->inRandomOrder()->value('id') ?? Author::factory(),
+            'publisher' => fake()->randomElement($publishers),
+            'published_year' => fake()->year(),
+            'description' => fake()->paragraph(3),
+            'cover_image' => 'https://placehold.co/400x600?text=' . urlencode(Str::limit($title, 20)),
+            'view_count' => fake()->numberBetween(100, 5000),
+            'avg_rating' => 0,
+        ];
+    }
+}

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        // Danh sách thể loại sách
+        $categories = [
+            'Sách Giáo Khoa',
+            'Văn Học Nước Ngoài',
+            'Văn Học Việt Nam',
+            'Tâm Lý - Kỹ Năng Sống',
+            'Sức Khỏe',
+            'Thiếu Nhi',
+            'Truyện Tranh',
+            'Tiểu Thuyết',
+            'Khoa Học Viễn Tưởng',
+            'Ngoại Ngữ',
+            'Nấu Ăn',
+            'Kinh Dị',
+            'Trinh Thám',
+            'Công Nghệ Thông Tin',
+            'Kinh Tế',
+            'Kinh Doanh',
+            'Lịch Sử',
+            'Chính Trị',
+            'Xã Hội',
+            'Tôn Giáo - Tâm Linh',
+        ];
+
+        // Dùng unique() để tránh trùng lặp tên thể loại
+        $name = fake()->unique()->randomElement($categories);
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'description' => 'Tuyển tập những cuốn sách hay nhất về chủ đề ' . $name,
+        ];
+    }
+}

--- a/database/factories/ReviewFactory.php
+++ b/database/factories/ReviewFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Book;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Review>
+ */
+class ReviewFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        // Lấy ngẫu nhiên một cuốn sách, nếu không có thì tạo mới
+        $book = Book::query()->inRandomOrder()->first() ?? Book::factory()->create();
+        return [
+            // Lấy ngẫu nhiên id từ bảng users, nếu không có thì tạo mới
+            'user_id' => User::query()->inRandomOrder()->value('id') ?? User::factory(),
+            'book_id' => $book->id,
+            // Ngẫu nhiên số điểm đánh giá từ 1 đến 5
+            'rating' => fake()->randomFloat(1, 1, 5),
+            'content_text' => fake()->paragraph(2),
+            // Test tỷ lệ duyệt (70% approved)
+            'is_approved' => fake()->boolean(70),
+            // Review được tạo sau khi sách được xuất bản
+            'created_at' => fake()->dateTimeBetween($book->published_year . '-01-01', 'now'),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,13 +23,39 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        // Ghi chú: Tạo tên đầy đủ
+        $name = fake()->lastName() . ' ' . fake()->middleName() . ' ' . fake()->firstName();
         return [
-            'name' => fake()->name(),
+            'name' => $name,
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            // Ghi chú: Pass mặc định: 123456789
+            'password' => static::$password ??= Hash::make('123456789'),
+            'avatar' => 'https://ui-avatars.com/api/?name=' . urlencode($name) . '&background=random&color=fff',
+            'bio' => fake()->randomElement([
+                'Một người đam mê sách cuồng nhiệt.',
+                'Thích sách.',
+                'Xin chào, tôi là một mọt sách.',
+                'Đang tìm kiếm những cuốn sách hay để review.',
+                'Tâm hồn tôi thuộc về những trang sách.',
+                'Yêu thích việc khám phá tri thức qua sách vở.',
+                'Sách là người bạn đồng hành tuyệt vời nhất của tôi.',
+                'Mỗi cuốn sách là một cuộc phiêu lưu mới.',
+                'Tôi sống để đọc và đọc để sống.',
+                'Chưa thiết lập tiểu sử.',
+            ]),
+            'role' => 'user',
+            'is_active' => true,
             'remember_token' => Str::random(10),
         ];
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'bio' => 'Quản trị viên hệ thống Góc Sách.',
+            'role' => 'admin',
+        ]);
     }
 
     /**
@@ -37,7 +63,7 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'email_verified_at' => null,
         ]);
     }

--- a/database/migrations/2025_11_26_171536_create_authors_table.php
+++ b/database/migrations/2025_11_26_171536_create_authors_table.php
@@ -16,6 +16,10 @@ return new class extends Migration
             $table->id();
             // Tên tác giả
             $table->string('name');
+            // Đường dẫn cho tác giả
+            $table->string('slug')->unique();
+            // Ảnh đại diện tác giả
+            $table->string('avatar')->nullable();
             // Tiểu sử tác giả
             $table->text('bio')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_11_26_171559_create_books_table.php
+++ b/database/migrations/2025_11_26_171559_create_books_table.php
@@ -10,18 +10,34 @@ return new class extends Migration
      * Run the migrations.
      */
     public function up(): void
-{
-    Schema::create('books', function (Blueprint $table) {
-        $table->id();
-        $table->string('title'); // Tên sách
-        $table->string('author')->nullable(); // Tác giả
-        $table->string('category')->nullable(); // Thể loại
-        $table->date('publish_date')->nullable(); // Ngày xuất bản
-        $table->string('image_url', 500)->nullable(); // Ảnh bìa
-        $table->text('description')->nullable(); // Mô tả
-        $table->timestamps();
-    });
-}
+    {
+        Schema::create('books', function (Blueprint $table) {
+            // Mã định danh sách
+            $table->id();
+            // Tiêu đề sách
+            $table->string('title');
+            // Đường dẫn sách
+            $table->string('slug')->unique();
+            // Mã định danh thể loại (Khóa ngoại)
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+            // Mã định danh tác giả (Khóa ngoại)
+            $table->foreignId('author_id')->constrained()->onDelete('cascade');
+            // Nhà xuất bản
+            $table->string('publisher')->nullable();
+            // Năm xuất bản
+            $table->integer('published_year')->nullable();
+            // Mô tả sách
+            $table->text('description')->nullable();
+            // Ảnh bìa sách
+            $table->string('cover_image')->nullable();
+            // Số lượt xem
+            $table->integer('view_count')->default(0);
+            // Đánh giá trung bình
+            $table->decimal('avg_rating', 3, 1)->default(0);
+            $table->timestamps();
+        });
+    }
+
     /**
      * Reverse the migrations.
      */

--- a/database/migrations/2025_11_26_171607_create_reviews_table.php
+++ b/database/migrations/2025_11_26_171607_create_reviews_table.php
@@ -18,8 +18,8 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
             // Mã định danh sách (Khóa ngoại)
             $table->foreignId('book_id')->constrained()->onDelete('cascade');
-            // Số sao đánh giá
-            $table->integer('rating_start');
+            // Số sao đánh giá (1-5)
+            $table->decimal('rating', 3, 1);
             // Nội dung đánh giá
             $table->text('content_text');
             // Trạng thái phê duyệt đánh giá

--- a/database/migrations/2025_11_26_171616_create_likes_table.php
+++ b/database/migrations/2025_11_26_171616_create_likes_table.php
@@ -19,6 +19,10 @@ return new class extends Migration
             // Mã định danh đánh giá (Khóa ngoại)
             $table->foreignId('review_id')->constrained()->onDelete('cascade');
             $table->timestamps();
+            // CỰC KÌ QUAN TRỌNG:
+            // Ghi chú: Tránh trường hợp 1 user có thể thích 1 bài review nhiều lần
+            // Dòng này tạo ràng buộc duy nhất giữa người dùng và bài review
+            $table->unique(['user_id', 'review_id']);
         });
     }
 

--- a/database/migrations/2025_11_26_172552_create_bookshelves_table.php
+++ b/database/migrations/2025_11_26_172552_create_bookshelves_table.php
@@ -25,6 +25,9 @@ return new class extends Migration
             // Ngày hoàn thành
             $table->date('finished_at')->nullable();
             $table->timestamps();
+            // CỰC KÌ QUAN TRỌNG: Tránh trường hợp 1 user có thể thêm cùng 1 cuốn sách vào kệ nhiều lần
+            // Dòng này tạo ràng buộc duy nhất giữa người dùng và cuốn sách đã chọn
+            $table->unique(['user_id', 'book_id']);
         });
     }
 

--- a/database/migrations/2025_11_26_172558_create_follows_table.php
+++ b/database/migrations/2025_11_26_172558_create_follows_table.php
@@ -19,6 +19,10 @@ return new class extends Migration
             // Mã định danh người được theo dõi (Khóa ngoại)
             $table->foreignId('following_id')->constrained('users')->onDelete('cascade');
             $table->timestamps();
+            // CỰC KÌ QUAN TRỌNG:
+            // Ghi chú: Tránh trường hợp 1 user có thể theo dõi 1 user khác nhiều lần
+            // Dòng này tạo ràng buộc duy nhất giữa nguời theo dõi và người được theo dõi
+            $table->unique(['follower_id', 'following_id']);
         });
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,8 +3,17 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Author;
+use App\Models\Book;
+use App\Models\Bookshelf;
+use App\Models\Category;
+use App\Models\Comment;
+use App\Models\Follow;
+use App\Models\Like;
+use App\Models\Review;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,11 +24,114 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        echo "Khởi tạo dữ liệu mẫu:\n";
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        // 1. Tạo người dùng (Admin và User)
+        User::factory()->admin()->create([
+            'name' => 'Admin',
+            'email' => 'admin@gmail.com',
+            'password' => bcrypt('123456789'),
         ]);
+
+        $users = User::factory(50)->create();
+        echo "Tạo thành công Users!\n";
+
+        // 2. Tạo danh mục
+        Category::factory(20)->create();
+
+        // 3. Tạo tác giả
+        Author::factory(20)->create();
+        echo "Tạo thành công Categories và Authors!\n";
+
+        // 4. Tạo sách
+        $books = Book::factory(50)->create();
+        echo "Tạo thành công Books!\n";
+
+        // 5. Tạo đánh giá
+        $reviews = Review::factory(200)->create();
+        echo "Tạo thành công Reviews!\n";
+
+        // 6. Tạo theo dõi
+        // Ghi chú: Mỗi người dùng sẽ theo dõi 3 người dùng ngẫu nhiên khác
+        foreach ($users as $user) {
+            // Ghi chú: Ngẫu nhiên 3 người dùng khác
+            $randomUsers = $users->where('id', '!=', $user->id)->random(3);
+            foreach ($randomUsers as $targetUser) {
+                // Ghi chú: Kiểm tra unique để tránh lỗi
+                if (!Follow::where('follower_id', $user->id)->where('following_id', $targetUser->id)->exists()) {
+                    Follow::create([
+                        'follower_id' => $user->id,
+                        'following_id' => $targetUser->id,
+                    ]);
+                }
+            }
+        }
+        echo "Tạo thành công Follows!\n";
+
+        // 7. Tạo bình luận và lượt thích
+        foreach ($reviews as $review) {
+            // Ghi chú: Ngẫu nhiên 0-3 bình luận cho mỗi đánh giá
+            $randomCommentCount = rand(0, 3);
+            for ($i = 0; $i < $randomCommentCount; $i++) {
+                Comment::create([
+                    'user_id' => $users->random()->id,
+                    'review_id' => $review->id,
+                    'content' => fake()->sentence(),
+                ]);
+            }
+
+            // Ghi chú: Ngẫu nhiên 0-20 lượt thích cho mỗi đánh giá, không thể vượt quá số người dùng hiện có
+            $randomLikeCount = rand(0, min(20, $users->count() - 1));
+            // Ghi chú: Ngẫu nhiên người dùng thích đánh giá
+            $randomLikers = $users->random($randomLikeCount);
+
+            foreach ($randomLikers as $liker) {
+                // Ghi chú: Kiểm tra unique trước khi tạo lượt thích
+                if (!Like::where('user_id', $liker->id)->where('review_id', $review->id)->exists()) {
+                    Like::create([
+                        'user_id' => $liker->id,
+                        'review_id' => $review->id,
+                    ]);
+                }
+            }
+        }
+        echo "Tạo thành công Comments và Likes!\n";
+
+        // 8. Tạo điểm trung bình cho sách
+        echo "Đang tính toán lại điểm trung bình cho từng cuốn sách...\n";
+        foreach ($books as $book) {
+            // Ghi chú: Tính điểm trung bình
+            $avg = $book->reviews()->avg('rating');
+
+            // Cập nhật vào sách (nếu không có review thì để 0)
+            $book->update([
+                'avg_rating' => $avg ?? 0,
+            ]);
+        }
+        echo "Tạo thành công Avg Ratings!\n";
+
+        // 9. Tạo giá sách cho mỗi người dùng
+        // Ghi chú: Mỗi người dùng sẽ có từ 0 đến 10 cuốn sách trên kệ
+        foreach ($users as $user) {
+            $randomBooks = $books->random(rand(0, 10));
+
+            foreach ($randomBooks as $book) {
+                // Ghi chú: Kiểm tra unique trước khi thêm vào kệ
+                if (!Bookshelf::where('user_id', $user->id)->where('book_id', $book->id)->exists()) {
+                    Bookshelf::create([
+                        'user_id' => $user->id,
+                        'book_id' => $book->id,
+                        'status' => fake()->randomElement(['wishlist', 'reading', 'completed']),
+                        // Ghi chú: 50% có ngày bắt đầu
+                        'started_at' => fake()->boolean(50) ? fake()->date() : null,
+                        // QUAN TRỌNG: ĐỂ TẠM THỜI
+                        'finished_at' => null,
+                    ]);
+                }
+            }
+        }
+        echo "Tạo thành công Bookshelves!\n";
+
+        echo "Tạo thành công toàn bộ dữ liệu mẫu!\n";
     }
 }


### PR DESCRIPTION
- Khởi tạo Models của 9 bảng.
- Khởi tạo 5 Factory của tác giả, sách, danh mục, đánh giá, người dùng.
- Tái cấu trúc lại Migrations của tác giả, sách, đánh giá, thích, kệ sách, theo dõi.
- Khởi tạo Seeder dữ liệu mẫu
+ Thêm quan hệ giữa các bảng
+ Thêm dữ liệu giả (có ý nghĩa) của tác giả, sách, danh mục, người dùng
+ Bổ sung slug và avatar của tác giả
+ Bổ sung đánh giá trung bình của sách
+ Chỉnh sửa lỗi sai chính tả tên đánh giá cũ (rating_start) -> đánh giá mới (rating)
+ Bổ sung đánh giá của người dùng
+ Thêm logic ràng buộc giữa người dùng và đánh giá
+ Thêm logic ràng buộc giữa người dùng và sách đã chọn
+ Thêm logic ràng buộc giữa người theo dõi và người được theo dõi
+ Thêm dữ liệu giả (tổng của toàn bộ 9 bảng) trong Seeder